### PR TITLE
Remove leading semicolon

### DIFF
--- a/keyvalueformatter/__init__.py
+++ b/keyvalueformatter/__init__.py
@@ -119,7 +119,7 @@ class KeyValueFormatter(logging.Formatter):
 
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
-        
+
         response = [self.prefix] if self.prefix else []
 
         sorted_entries = sorted([(k, v) for k, v in iteritems(log_record)])

--- a/keyvalueformatter/__init__.py
+++ b/keyvalueformatter/__init__.py
@@ -119,8 +119,8 @@ class KeyValueFormatter(logging.Formatter):
 
         self.add_fields(log_record, record, message_dict)
         log_record = self.process_log_record(log_record)
-
-        response = [self.prefix]
+        
+        response = [self.prefix] if self.prefix else []
 
         sorted_entries = sorted([(k, v) for k, v in iteritems(log_record)])
         for key, value in sorted_entries:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_requirements = [
 
 setup(
     name='keyvalueformatter',
-    version='0.0.2',
+    version='0.0.3',
     description='Allows easy key=value formatting for standard python logging',
     long_description=readme,
     author='Kyle James Walker',

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -25,7 +25,7 @@ class LogTestCase(unittest.TestCase):
         '''
         self.logger.info("a message")
         self.assertEqual(self.buffer.getvalue(),
-                         ';message="a message"\n')
+                         'message="a message"\n')
 
     def test_dict_format(self):
         '''Make sure the logger can take a message within a dictionary
@@ -36,7 +36,7 @@ class LogTestCase(unittest.TestCase):
         ))
 
         self.assertEqual(self.buffer.getvalue(),
-                         ';message="a message"\n')
+                         'message="a message"\n')
 
     def test_dict_with_fields(self):
         '''Make sure the logger can handle complex types

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -52,20 +52,20 @@ class LogTestCase(unittest.TestCase):
 
         if "u'" in self.buffer.getvalue():
             self.assertEqual(self.buffer.getvalue(),
-                            '''dict="{u'hello': u'world'}"'''
-                            ''';=field="True"'''
-                            ''';list="[u'nice', u'time']"'''
-                            ''';message="a message"'''
-                            ''';more="More goes here"'''
-                            '''\n''')
+                             '''dict="{u'hello': u'world'}"'''
+                             ''';field="True"'''
+                             ''';list="[u'nice', u'time']"'''
+                             ''';message="a message"'''
+                             ''';more="More goes here"'''
+                             '''\n''')
         else:
             self.assertEqual(self.buffer.getvalue(),
-                            '''dict="{'hello': 'world'}"'''
-                            ''';field="True"'''
-                            ''';list="['nice', 'time']"'''
-                            ''';message="a message"'''
-                            ''';more="More goes here"'''
-                            '''\n''')
+                             '''dict="{'hello': 'world'}"'''
+                             ''';field="True"'''
+                             ''';list="['nice', 'time']"'''
+                             ''';message="a message"'''
+                             ''';more="More goes here"'''
+                             '''\n''')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -52,15 +52,15 @@ class LogTestCase(unittest.TestCase):
 
         if "u'" in self.buffer.getvalue():
             self.assertEqual(self.buffer.getvalue(),
-                            ''';dict="{u'hello': u'world'}"'''
-                            ''';field="True"'''
+                            '''dict="{u'hello': u'world'}"'''
+                            ''';=field="True"'''
                             ''';list="[u'nice', u'time']"'''
                             ''';message="a message"'''
                             ''';more="More goes here"'''
                             '''\n''')
         else:
             self.assertEqual(self.buffer.getvalue(),
-                            ''';dict="{'hello': 'world'}"'''
+                            '''dict="{'hello': 'world'}"'''
                             ''';field="True"'''
                             ''';list="['nice', 'time']"'''
                             ''';message="a message"'''


### PR DESCRIPTION
## Summary

There is an extra leading semicolon on outputted logs when the `prefix` variable of the `KeyValueFormatter` is empty.

Example:

```
;asctime="2015-11-10 16:46:52"; ... rest of log line
```

This PR turns that into this:

```
asctime="2015-11-10 16:46:52"; ... rest of log line # no more leading semicolon yay!
```
